### PR TITLE
Fix orderBy call in TaskController

### DIFF
--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -12,7 +12,7 @@ class TaskController extends Controller
      */
     public function index()
     {
-        $tasks = Task::orderby('created_at', 'desc')->get();
+        $tasks = Task::orderBy('created_at', 'desc')->get();
         return view('tasks.index', compact('tasks'));
 
     }


### PR DESCRIPTION
## Summary
- use `orderBy` with correct casing for Task model queries

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684a5b997b9c8329abb8a58fb0e19e5a